### PR TITLE
feat: aggregates-size-limits rule

### DIFF
--- a/src/rules/aggregates-size-limits.rule.ts
+++ b/src/rules/aggregates-size-limits.rule.ts
@@ -1,0 +1,101 @@
+/**
+ * **aggregates-size-limits :**
+ * Aggregates mustn't contain more tha 3 dependencies to entities
+ *
+ * ## Examples
+ *
+ * Example of incorrect dragees for this rule:
+ *
+ * ```json
+ *  {
+        "name": "AValueObject1",
+        "profile": "ddd/entity"
+    },
+    {
+        "name": "AValueObject2",
+        "profile": "ddd/entity"
+    },
+    {
+        "name": "AValueObject3",
+        "profile": "ddd/entity"
+    },
+    {
+        "name": "AValueObject4",
+        "profile": "ddd/entity"
+    },
+    {
+        "name": "AnAggregate",
+        "profile": "ddd/aggregate",
+        "depends_on": {
+            "AValueObject1": ["field"],
+            "AValueObject2": ["field"],
+            "AValueObject3": ["field"],
+            "AValueObject4": ["field"]
+        }
+    }
+ * ```
+ *
+ * Example of correct dragees for this rule:
+ *
+ * ```json
+ *  {
+        "name": "AValueObject1",
+        "profile": "ddd/entity"
+    },
+    {
+        "name": "AValueObject2",
+        "profile": "ddd/entity"
+    },
+    {
+        "name": "AValueObject3",
+        "profile": "ddd/entity"
+    },
+    {
+        "name": "AnAggregate",
+        "profile": "ddd/aggregate",
+        "depends_on": {
+            "AValueObject1": ["field"],
+            "AValueObject2": ["field"],
+            "AValueObject3": ["field"]
+        }
+    }
+ * ```
+ *
+ * @module Aggregates Size Limits
+ *
+ */
+import {
+    type RuleResult,
+    RuleSeverity,
+    directDependencies,
+    expectDragees
+} from '@dragee-io/type/asserter';
+import type { Dragee, DrageeDependency } from '@dragee-io/type/common';
+import { aggregateProfile, entityProfile, profiles } from '../ddd.model.ts';
+
+const NUMBER_OF_ENTITIES_LIMIT = 3;
+
+const ensureDrageeSizeLimits = ({ root, dependencies }: DrageeDependency): RuleResult =>
+    expectDragees(
+        root,
+        dependencies,
+        `This aggregate mustn't contain more than 3 "ddd/entity" type of dragees`,
+        dependencies => !isLimitSizeExceeded(dependencies)
+    );
+
+function isLimitSizeExceeded(dependencies: Dragee[]): boolean {
+    return (
+        dependencies.reduce((acc, dep) => (dep.profile === entityProfile ? acc + 1 : acc), 0) >
+        NUMBER_OF_ENTITIES_LIMIT
+    );
+}
+
+export default {
+    label: 'Aggregates Size Limits',
+    severity: RuleSeverity.ERROR,
+    handler: (dragees: Dragee[]): RuleResult[] =>
+        profiles[aggregateProfile]
+            .findIn(dragees)
+            .map(aggregate => directDependencies(aggregate, dragees))
+            .map(ensureDrageeSizeLimits)
+};

--- a/src/test/ddd-asserter.spec.ts
+++ b/src/test/ddd-asserter.spec.ts
@@ -42,6 +42,7 @@ describe('DDD Asserter', () => {
     describe('Aggregate Rules', () => {
         const AGGREGATE_DEPENDENCY_DRAGEE_TEST_DIRECTORY = './ddd/aggregates-dependencies-rules';
         const AGGREGATE_MANDATORY_DRAGEE_TEST_DIRECTORY = './ddd/aggregates-mandatories-rules';
+        const AGGREGATE_SIZE_LIMITS_DRAGEE_TEST_DIRECTORY = './ddd/aggregates-size-limits-rules';
 
         describe('An aggregate must contain only value objects, entities, or events', () => {
             rulePassed(`${AGGREGATE_DEPENDENCY_DRAGEE_TEST_DIRECTORY}/rule-passed.json`);
@@ -50,6 +51,11 @@ describe('DDD Asserter', () => {
         describe('An aggregate must at least contains one entity', () => {
             rulePassed(`${AGGREGATE_MANDATORY_DRAGEE_TEST_DIRECTORY}/rule-passed.json`);
             ruleFailed(`${AGGREGATE_MANDATORY_DRAGEE_TEST_DIRECTORY}/rule-failed.json`);
+        });
+
+        describe(`An aggregate must not have more than 3 dependencies to entities`, () => {
+            rulePassed(`${AGGREGATE_SIZE_LIMITS_DRAGEE_TEST_DIRECTORY}/rule-passed.json`);
+            ruleFailed(`${AGGREGATE_SIZE_LIMITS_DRAGEE_TEST_DIRECTORY}/rule-failed.json`);
         });
     });
     describe('Repository Rules', () => {

--- a/src/test/ddd/aggregates-size-limits-rules/rule-failed.json
+++ b/src/test/ddd/aggregates-size-limits-rules/rule-failed.json
@@ -1,0 +1,40 @@
+{
+    "dragees": [
+        {
+            "name": "AValueObject1",
+            "profile": "ddd/entity"
+        },
+        {
+            "name": "AValueObject2",
+            "profile": "ddd/entity"
+        },
+        {
+            "name": "AValueObject3",
+            "profile": "ddd/entity"
+        },
+        {
+            "name": "AValueObject4",
+            "profile": "ddd/entity"
+        },
+        {
+            "name": "AnAggregate",
+            "profile": "ddd/aggregate",
+            "depends_on": {
+                "AValueObject1": ["field"],
+                "AValueObject2": ["field"],
+                "AValueObject3": ["field"],
+                "AValueObject4": ["field"]
+            }
+        }
+    ],
+    "result": {
+        "pass": false,
+        "errors": [
+            {
+                "drageeName": "AnAggregate",
+                "message": "This aggregate mustn't contain more than 3 \"ddd/entity\" type of dragees",
+                "ruleId": "ddd/aggregates-size-limits"
+            }
+        ]
+    }
+}

--- a/src/test/ddd/aggregates-size-limits-rules/rule-passed.json
+++ b/src/test/ddd/aggregates-size-limits-rules/rule-passed.json
@@ -1,0 +1,28 @@
+{
+    "dragees": [
+        {
+            "name": "AValueObject1",
+            "profile": "ddd/entity"
+        },
+        {
+            "name": "AValueObject2",
+            "profile": "ddd/entity"
+        },
+        {
+            "name": "AValueObject3",
+            "profile": "ddd/entity"
+        },
+        {
+            "name": "AnAggregate",
+            "profile": "ddd/aggregate",
+            "depends_on": {
+                "AValueObject1": ["field"],
+                "AValueObject2": ["field"],
+                "AValueObject3": ["field"]
+            }
+        }
+    ],
+    "result": {
+        "pass": true
+    }
+}


### PR DESCRIPTION
Adds the `aggreates-size-limits`. This rule will ensure every aggregates doesn't have too many aggregates.